### PR TITLE
add an ar_entry_zip_get_raw_name to read zip entry raw name

### DIFF
--- a/unarr.h
+++ b/unarr.h
@@ -89,6 +89,9 @@ UNARR_EXPORT bool ar_at_eof(ar_archive *ar);
 
 /* returns the name of the current entry as UTF-8 string; this pointer is only valid until the next call to ar_parse_entry; returns NULL on failure */
 UNARR_EXPORT const char *ar_entry_get_name(ar_archive *ar);
+
+/* returns raw zip entry name without encoding convert and slash replace (but only preserve parts before any null terminator, if such invalid terminator inside filename)*/
+UNARR_EXPORT const char *ar_entry_zip_get_raw_name(ar_archive *ar);
 /* returns the stream offset of the current entry for use with ar_parse_entry_at */
 UNARR_EXPORT off64_t ar_entry_get_offset(ar_archive *ar);
 /* returns the total size of uncompressed data of the current entry; read exactly that many bytes using ar_entry_uncompress */

--- a/zip/parse-zip.c
+++ b/zip/parse-zip.c
@@ -268,6 +268,16 @@ off64_t zip_find_end_of_central_directory(ar_stream *stream)
     return -1;
 }
 
+const char *ar_entry_zip_get_raw_name(ar_archive *ar)
+{
+    ar_archive_zip *zip = (ar_archive_zip *)ar;
+    if (zip->entry.raw_name)
+        return zip->entry.raw_name;
+
+    zip_get_name(ar);
+    return zip->entry.raw_name;
+}
+
 const char *zip_get_name(ar_archive *ar)
 {
     ar_archive_zip *zip = (ar_archive_zip *)ar;
@@ -299,6 +309,7 @@ const char *zip_get_name(ar_archive *ar)
         }
         name[entry.namelen] = '\0';
 
+        zip->entry.raw_name = strdup(name);
         if ((entry.flags & (1 << 11))) {
             zip->entry.name = name;
         }

--- a/zip/zip.c
+++ b/zip/zip.c
@@ -7,6 +7,7 @@ static void zip_close(ar_archive *ar)
 {
     ar_archive_zip *zip = (ar_archive_zip *)ar;
     free(zip->entry.name);
+    free(zip->entry.raw_name);
     zip_clear_uncompress(&zip->uncomp);
 }
 
@@ -45,6 +46,8 @@ static bool zip_parse_local_entry(ar_archive *ar, off64_t offset)
     zip->entry.crc = entry.crc;
     free(zip->entry.name);
     zip->entry.name = NULL;
+    free(zip->entry.raw_name);
+    zip->entry.raw_name = NULL;
     zip->entry.dosdate = entry.dosdate;
 
     zip->progress.crc = 0;
@@ -93,6 +96,8 @@ static bool zip_parse_entry(ar_archive *ar, off64_t offset)
     zip->entry.crc = entry.crc;
     free(zip->entry.name);
     zip->entry.name = NULL;
+    free(zip->entry.raw_name);
+    zip->entry.raw_name = NULL;
     zip->entry.dosdate = entry.dosdate;
 
     zip->progress.crc = 0;

--- a/zip/zip.h
+++ b/zip/zip.h
@@ -80,6 +80,7 @@ struct ar_archive_zip_entry {
     uint16_t flags;
     uint32_t crc;
     char *name;
+    char *raw_name;
     uint32_t dosdate;
 };
 


### PR DESCRIPTION
due to zip format not restrict for name encoding, filename can be
encoded as many variants. this interface get original filename
without encoding convert and slash replace (but only preserve part
before \0 if invalid null terminator inside filename)