### PR TITLE
Update support for LoongArch.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@
 * Felix Kauselmann (licorn at gmail.com)
 * Bastien Nocera (hadess@hadess.net, http://www.hadess.net/)
 * Wang Xinyu (comicfans44 at gmail.com)
+* Liu Xiang (liuxiang@loongson.cn, https://www.loongson.cn/)
 
 Most code is licensed under LGPLv3 (see COPYING). Exceptions are in code
 included from other projects:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Create CMake config-files for downstream integration
 * New ar_entry_get_raw_name function for getting raw zip filenames (usefull for faulty
   zip archives with non-spec filename encodings)
+* Support for Loongson CPUs (Liu Xiang)
 
 ### Changed
 * Update LZMA SDK code to version 19.00

--- a/lzmasdk/CpuArch.h
+++ b/lzmasdk/CpuArch.h
@@ -83,9 +83,7 @@ MY_CPU_LE_UNALIGN means that CPU is LITTLE ENDIAN and CPU supports unaligned mem
 #endif
 
 
-#if  defined(__loongarch64) \
-  || defined(__loongarch__) \
-  || (defined(__loongarch) && (__loongarch == 64))
+#if  defined(__loongarch64) 
   #define MY_CPU_NAME "loongarch64"
   #define MY_CPU_64BIT
 #endif

--- a/lzmasdk/CpuArch.h
+++ b/lzmasdk/CpuArch.h
@@ -83,6 +83,14 @@ MY_CPU_LE_UNALIGN means that CPU is LITTLE ENDIAN and CPU supports unaligned mem
 #endif
 
 
+#if  defined(__loongarch64) \
+  || defined(__loongarch__) \
+  || (defined(__loongarch) && (__loongarch == 64))
+  #define MY_CPU_NAME "loongarch64"
+  #define MY_CPU_64BIT
+#endif
+
+
 #if  defined(__ppc64__) \
   || defined(__powerpc64__)
   #ifdef __ILP32__
@@ -140,6 +148,7 @@ MY_CPU_LE_UNALIGN means that CPU is LITTLE ENDIAN and CPU supports unaligned mem
     || defined(__MIPSEL__) \
     || defined(__MIPSEL) \
     || defined(_MIPSEL) \
+    || defined(_LOONGARCH_ARCH_LOONGARCH64) \
     || defined(__BFIN__) \
     || (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
   #define MY_CPU_LE


### PR DESCRIPTION
After the GCC version is updated, the definition of Gcc macro changes.