### PR TITLE
Add fuzzer test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@
 * Simon Bünzli (zeniko at gmail.com, http://www.zeniko.ch/#SumatraPDF)
 * Felix Kauselmann (licorn at gmail.com)
 * Bastien Nocera (hadess at hadess.net, http://www.hadess.net/)
-* Wang Xinyu (comicfans44 at gmail.com)
+* Wang Xin-yu (王昕宇) (comicfans44 at gmail.com)
 * Liu Xiang (liuxiang at loongson.cn, https://www.loongson.cn/)
 * Mastercoms (mastercoms at tuta.io)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.1.0 (unreleased)
 
+### Added
+* libFuzzer target for coverage-guided fuzz testing (Wang Xin-yu (王昕宇))
+
 ### Changed
 * Build 7z support by default
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,17 @@ option(USE_SYSTEM_LZMA "Build with system lzma/xz if possible" ON)
 option(USE_SYSTEM_ZLIB "Build with system zlib if possible" ON)
 option(USE_ZLIB_CRC "Use zlib crc32" OFF)
 
+option(BUILD_FUZZER "Build libFuzzer coverage-guided fuzzer test" OFF)
+
+if(BUILD_FUZZER)
+  if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    set(sanitize_opts "-fsanitize=fuzzer,address,undefined")
+    enable_testing()
+    add_subdirectory(test)
+  else()
+    error("Fuzzer build requires a Clang compiler")
+  endif()
+endif()
 
 # Build target
 add_library(unarr
@@ -164,7 +175,7 @@ if(ENABLE_7Z)
 target_compile_definitions(unarr PRIVATE -DHAVE_7Z -D_7ZIP_PPMD_SUPPPORT)
 endif()
 
-if(BUILD_SAMPLES)
+if(BUILD_SAMPLES AND NOT BUILD_FUZZER)
   add_executable(unarr-test
                 test/main.c)
   add_dependencies(unarr-test unarr)
@@ -178,25 +189,34 @@ if(UNIX OR MINGW OR MSYS)
                     -Wstrict-prototypes -Wmissing-prototypes
                     -Werror-implicit-function-declaration
                     $<$<CONFIG:Release>:-fomit-frame-pointer>
-                    $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>>:
+                    $<$<C_COMPILER_ID:Clang,AppleClang>:
                     -Wno-missing-field-initializers>
                     -flto)
+  if (BUILD_FUZZER)
+    target_compile_options(unarr PUBLIC "${sanitize_opts}")
+    target_compile_definitions(unarr PRIVATE -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
+  endif()
+
   target_compile_definitions(unarr PRIVATE -D_FILE_OFFSET_BITS=64)
 
   # Linker flags
 
-  # Clang linker needs -flto too when doing lto
-  if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-    set_target_properties(unarr PROPERTIES LINK_FLAGS
-                          "-Wl,--no-undefined -Wl,--as-needed -flto")
-  # Apple ld uses different syntax for undefined symbol check
-  elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
-    set_target_properties(unarr PROPERTIES LINK_FLAGS
-                          "-Wl,-undefined,error -flto")
+  if(BUILD_FUZZER)
+    set(linker_opts "${sanitize_opts}")
   else()
-    set_target_properties(unarr PROPERTIES LINK_FLAGS
-                          "-Wl,--no-undefined -Wl,--as-needed")
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
+      set(linker_opts "-Wl,-undefined,error")
+    else()
+      set(linker_opts "-Wl,--as-needed -Wl,--no-undefined")
+    endif()
   endif()
+
+  # Clang linker needs -flto too when doing lto
+  if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+    set (linker_opts "${linker_opts} -flto")
+  endif()
+
+  set_target_properties(unarr PROPERTIES LINK_FLAGS "${linker_opts}")
 endif()
 
 if(MSVC)

--- a/common/unarr-imp.h
+++ b/common/unarr-imp.h
@@ -43,8 +43,11 @@ struct ar_stream_s {
 ar_stream *ar_open_stream(void *data, ar_stream_close_fn close, ar_stream_read_fn read, ar_stream_seek_fn seek, ar_stream_tell_fn tell);
 
 /***** unarr *****/
-
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 #define warn(...) ar_log("!", __FILE__, __LINE__, __VA_ARGS__)
+#else
+#define warn(...) ((void)0)
+#endif
 #ifndef NDEBUG
 #define log(...) ar_log("-", __FILE__, __LINE__, __VA_ARGS__)
 #else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,20 @@
+project (unarr-test C)
+
+include(CTest)
+include(ProcessorCount)
+ProcessorCount(N)
+
+if (BUILD_FUZZER)
+  add_executable(fuzzer fuzzer.c)
+  set_target_properties(fuzzer PROPERTIES LINK_FLAGS "${sanitize_opts}")
+  target_link_libraries(fuzzer unarr)
+
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/corpus)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/corpus/fuzzed)
+
+  add_test(NAME fuzzer_test
+          COMMAND fuzzer
+            ${CMAKE_CURRENT_SOURCE_DIR}/corpus/fuzzed
+            ${CMAKE_CURRENT_SOURCE_DIR}/corpus
+            -jobs=${N})
+endif()

--- a/test/fuzzer.c
+++ b/test/fuzzer.c
@@ -1,0 +1,65 @@
+#include "unarr.h"
+#include <stdio.h>
+
+ar_archive *ar_open_any_archive(ar_stream *stream) {
+  ar_archive *ar = ar_open_zip_archive(stream, false);
+  if (!ar)
+    ar = ar_open_zip_archive(stream, true);
+  if (!ar)
+    ar = ar_open_rar_archive(stream);
+  if (!ar)
+    ar = ar_open_7z_archive(stream);
+  if (!ar)
+    ar = ar_open_tar_archive(stream);
+  return ar;
+}
+
+void read_test(ar_stream *stream) {
+
+  ar_archive *ar = ar_open_any_archive(stream);
+
+  if (!ar) {
+    return;
+  }
+
+  while (true) {
+
+    if (ar_at_eof(ar)) {
+      break;
+    }
+
+    bool ok = ar_parse_entry(ar);
+
+    if (!ok) {
+      break;
+    }
+
+    size_t size = ar_entry_get_size(ar);
+    while (size > 0) {
+      unsigned char buffer[1024];
+      size_t count = size < sizeof(buffer) ? size : sizeof(buffer);
+      if (!ar_entry_uncompress(ar, buffer, count))
+        break;
+      size -= count;
+    }
+  }
+
+  if (!ar_at_eof(ar)) {
+    printf("not reach eof\n");
+  }
+
+  ar_close_archive(ar);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+
+  ar_stream *stream;
+
+  stream = ar_open_memory(Data, Size);
+
+  read_test(stream);
+
+  ar_close(stream);
+
+  return 0; // Non-zero return values are reserved for future use.
+}


### PR DESCRIPTION
Create a BUILD_FUZZER build option, which will turn on clang
fuzzer with address and undefined behavior sanitizer and add
a fuzzer_test test to fuzz unarr

Co-authored-by: Felix Kauselmann <licorn@gmail.com>