### PR TITLE
CMake: indicate compatibility up to CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.3...4.0 FATAL_ERROR)
 
 project(
   unarr


### PR DESCRIPTION
CMake 4.0 dropped compatibility with CMake versions < 3.5, making it impossible to use unarr with current cmake versions. 
This PR marks the project as compatible up to 4.0 while retaining the original minimum version. 
A quick test in https://github.com/nba-emu/NanoBoyAdvance indicated that this is working as intended and I didn't spot anything in the CMake that shouldn't work in modern CMake at a quick glance.